### PR TITLE
Fix default ES port number

### DIFF
--- a/cmd/root.es.go
+++ b/cmd/root.es.go
@@ -33,6 +33,6 @@ var esScheme string
 func init() {
 	rootCmd.AddCommand(esCmd)
 	esCmd.PersistentFlags().StringVar(&esHost, "es-host", "localhost", "Hostname of ES load balancer or cluster member")
-	esCmd.PersistentFlags().StringVar(&esPort, "es-port", "10141", "Port number of ES load balancer or cluster member")
+	esCmd.PersistentFlags().StringVar(&esPort, "es-port", "10144", "Port number of ES load balancer or cluster member")
 	esCmd.PersistentFlags().StringVar(&esScheme, "es-scheme", "http", "Scheme can be http or https")
 }


### PR DESCRIPTION
Automate changed the ES load balancer port from 10141 to 10144
This PR fixes the default